### PR TITLE
fix: set correct file to use in workflow file example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ on:
 
 jobs:
     documentation-linter:
-    uses: minvws/workflow-documentation-linter/.github/workflows/repo-sync.yml@main
+    uses: minvws/workflow-documentation-linter/.github/workflows/documentation-linter.yml@main
 ```
 
 </details>


### PR DESCRIPTION
whoops:
<img width="1228" height="1581" alt="Scherm­afbeelding 2025-08-27 om 11 02 19" src="https://github.com/user-attachments/assets/2f2f3ca7-7bb8-475f-929f-3b3194f790dc" />

it seems a copy/paste mistake from another example